### PR TITLE
Add missing dependency on drracket (for docs)

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -16,5 +16,6 @@
     "scribble-lib"
     "racket-doc"
     "scribble-doc"
+    "drracket"
     ))
 


### PR DESCRIPTION
On my machine (racket v6.9.0.4 20170517-8bc9cef7a9), `raco setup -iDxn --check-pkg-deps` gives:

```
.raco-wrapped: --- checking package dependencies ---
.raco-wrapped: found undeclared dependency:
.raco-wrapped:   mode: build (of documentation)
.raco-wrapped:   for package: "debug"
.raco-wrapped:   on package: "drracket"
.raco-wrapped:   from document: "debug"
.raco-wrapped:   to document: "drracket"
```