### PR TITLE
handle multiple-valued results in `report`

### DIFF
--- a/debug/report.rkt
+++ b/debug/report.rkt
@@ -20,9 +20,9 @@
   (syntax-case stx ()
     [(_ expr) #'(report expr expr)]
     [(_ expr name)
-     #'(let ([expr-result expr]) 
-         (eprintf "~a = ~v\n" 'name expr-result)
-         expr-result)]))
+     #'(let ([expr-results (call-with-values (λ () expr) list)]) 
+         (eprintf "~a = ~a\n" 'name (stringify-results expr-results))
+         (apply values expr-results))]))
 
 
 (define-syntax (report/line stx)
@@ -30,9 +30,9 @@
     [(_ expr) #'(report/line expr expr)]
     [(_ expr name)
      (with-syntax ([line (syntax-line #'expr)])
-       #'(let ([expr-result expr])
-           (eprintf "~a = ~v on line ~v\n" 'name expr-result 'line)
-           expr-result))]))
+       #'(let ([expr-results (call-with-values (λ () expr) list)])
+           (eprintf "~a = ~a on line ~a\n" 'name (stringify-results expr-results) 'line)
+           (apply values expr-results)))]))
 
 
 (define-syntax (report/file stx)
@@ -41,9 +41,9 @@
     [(_ expr name)
      (with-syntax ([file (syntax-source #'expr)]
                    [line (syntax-line #'expr)])
-       #'(let ([expr-result expr])
-           (eprintf "~a = ~v on line ~v in \"~a\"\n" 'name expr-result 'line 'file)
-           expr-result))]))
+       #'(let ([expr-results (call-with-values (λ () expr) list)])
+           (eprintf "~a = ~a on line ~a in \"~a\"\n" 'name (stringify-results expr-results) 'line 'file)
+           (apply values expr-results)))]))
 
 
 (define-syntax-rule (define-multi-version multi-name name)

--- a/debug/report.rkt
+++ b/debug/report.rkt
@@ -20,9 +20,10 @@
   (syntax-case stx ()
     [(_ expr) #'(report expr expr)]
     [(_ expr name)
-     #'(let ([expr-results (call-with-values (λ () expr) list)]) 
-         (eprintf "~a = ~a\n" 'name (stringify-results expr-results))
-         (apply values expr-results))]))
+     #'(pass-through-values
+        (λ () expr)
+        (λ (expr-results)
+          (eprintf "~a = ~a\n" 'name (stringify-results expr-results))))]))
 
 
 (define-syntax (report/line stx)
@@ -30,9 +31,11 @@
     [(_ expr) #'(report/line expr expr)]
     [(_ expr name)
      (with-syntax ([line (syntax-line #'expr)])
-       #'(let ([expr-results (call-with-values (λ () expr) list)])
-           (eprintf "~a = ~a on line ~a\n" 'name (stringify-results expr-results) 'line)
-           (apply values expr-results)))]))
+       #'(pass-through-values
+          (λ () expr)
+          (λ (expr-results)
+            (eprintf "~a = ~a on line ~a\n"
+                     'name (stringify-results expr-results) 'line))))]))
 
 
 (define-syntax (report/file stx)
@@ -41,9 +44,11 @@
     [(_ expr name)
      (with-syntax ([file (syntax-source #'expr)]
                    [line (syntax-line #'expr)])
-       #'(let ([expr-results (call-with-values (λ () expr) list)])
-           (eprintf "~a = ~a on line ~a in \"~a\"\n" 'name (stringify-results expr-results) 'line 'file)
-           (apply values expr-results)))]))
+       #'(pass-through-values
+          (λ () expr)
+          (λ (expr-results)
+            (eprintf "~a = ~a on line ~a in \"~a\"\n"
+                     'name (stringify-results expr-results) 'line 'file))))]))
 
 
 (define-syntax-rule (define-multi-version multi-name name)

--- a/debug/report.rkt
+++ b/debug/report.rkt
@@ -22,8 +22,7 @@
     [(_ expr name)
      #'(pass-through-values
         (λ () expr)
-        (λ (expr-results)
-          (eprintf "~a = ~a\n" 'name (stringify-results expr-results))))]))
+        (effect/report 'name))]))
 
 
 (define-syntax (report/line stx)
@@ -33,9 +32,7 @@
      (with-syntax ([line (syntax-line #'expr)])
        #'(pass-through-values
           (λ () expr)
-          (λ (expr-results)
-            (eprintf "~a = ~a on line ~a\n"
-                     'name (stringify-results expr-results) 'line))))]))
+          (effect/report/line 'name 'line)))]))
 
 
 (define-syntax (report/file stx)
@@ -46,9 +43,7 @@
                    [line (syntax-line #'expr)])
        #'(pass-through-values
           (λ () expr)
-          (λ (expr-results)
-            (eprintf "~a = ~a on line ~a in \"~a\"\n"
-                     'name (stringify-results expr-results) 'line 'file))))]))
+          (effect/report/file 'name 'line 'file)))]))
 
 
 (define-syntax-rule (define-multi-version multi-name name)

--- a/debug/report/helpers.rkt
+++ b/debug/report/helpers.rkt
@@ -16,7 +16,7 @@
 ;; pass-through-values :
 ;; (∀ (X ...)
 ;;   (-> (-> (values X ...))
-;;       (-> (List X ...) Void)
+;;       (-> (Listof Any) Void)
 ;;       (values X ...)))
 (define (pass-through-values thunk effect)
   (let ([lst (call-with-values thunk list)])

--- a/debug/report/helpers.rkt
+++ b/debug/report/helpers.rkt
@@ -6,3 +6,15 @@
 ;; Type annotations for these helpers should go in
 ;; typed/debug/report/helpers.rkt
 
+(provide stringify-results)
+
+(require racket/string)
+
+;; stringify-results : (Listof Any) -> String
+(define (stringify-results expr-results)
+  (format (if (= 1 (length expr-results))
+              "~a"
+              "(values ~a)")
+          (string-join (for/list ([r (in-list expr-results)])
+                         (format "~v" r))
+                       " ")))

--- a/debug/report/helpers.rkt
+++ b/debug/report/helpers.rkt
@@ -6,9 +6,20 @@
 ;; Type annotations for these helpers should go in
 ;; typed/debug/report/helpers.rkt
 
-(provide stringify-results)
+(provide pass-through-values
+         stringify-results)
 
 (require racket/string)
+
+;; pass-through-values :
+;; (∀ (X ...)
+;;   (-> (-> (values X ...))
+;;       (-> (List X ...) Void)
+;;       (values X ...)))
+(define (pass-through-values thunk effect)
+  (let ([lst (call-with-values thunk list)])
+    (effect lst)
+    (apply values lst)))
 
 ;; stringify-results : (Listof Any) -> String
 (define (stringify-results expr-results)

--- a/debug/report/helpers.rkt
+++ b/debug/report/helpers.rkt
@@ -7,7 +7,9 @@
 ;; typed/debug/report/helpers.rkt
 
 (provide pass-through-values
-         stringify-results)
+         effect/report
+         effect/report/line
+         effect/report/file)
 
 (require racket/string)
 
@@ -20,6 +22,23 @@
   (let ([lst (call-with-values thunk list)])
     (effect lst)
     (apply values lst)))
+
+;; effect/report : Any -> [(Listof Any) -> Void]
+(define ((effect/report name) expr-results)
+  (eprintf "~a = ~a\n"
+           name (stringify-results expr-results)))
+
+;; effect/report/line : Any Natural -> [(Listof Any) -> Void]
+(define ((effect/report/line name line) expr-results)
+  (eprintf "~a = ~a on line ~a\n"
+           name (stringify-results expr-results) line))
+
+;; effect/report/file : Any Natural Any -> [(Listof Any) -> Void]
+(define ((effect/report/file name line file) expr-results)
+  (eprintf "~a = ~a on line ~a in ~v\n"
+           name (stringify-results expr-results) line file))
+
+;; -------------------------------------------------------------------
 
 ;; stringify-results : (Listof Any) -> String
 (define (stringify-results expr-results)

--- a/typed/debug/report/helpers.rkt
+++ b/typed/debug/report/helpers.rkt
@@ -4,4 +4,5 @@
 
 (type-environment
  ;; type annotations for report helpers go here:
+ [stringify-results (-> (-lst Univ) -String)]
  )

--- a/typed/debug/report/helpers.rkt
+++ b/typed/debug/report/helpers.rkt
@@ -8,13 +8,13 @@
  [pass-through-values
   ;; (∀ (X ...)
   ;;   (-> (-> (values X ...))
-  ;;       (-> (List X ...) Void)
+  ;;       (-> (Listof Any) Void)
   ;;       (values X ...)))
   (-polydots (x)
     (cl->*
      (->
       (-> (-values-dots (list) x 'x))
-      (-> (make-ListDots x 'x) -Void)
+      (-> (-lst Univ) -Void)
       (-values-dots (list) x 'x))))]
 
  [effect/report       (-> Univ           (-> (-lst Univ) -Void))]

--- a/typed/debug/report/helpers.rkt
+++ b/typed/debug/report/helpers.rkt
@@ -4,5 +4,17 @@
 
 (type-environment
  ;; type annotations for report helpers go here:
+ [pass-through-values
+  ;; (∀ (X ...)
+  ;;   (-> (-> (values X ...))
+  ;;       (-> (List X ...) Void)
+  ;;       (values X ...)))
+
+  (-polydots (x)
+    (cl->*
+     (->
+      (-> (-values-dots (list) x 'x))
+      (-> (make-ListDots x 'x) -Void)
+      (-values-dots (list) x 'x))))]
  [stringify-results (-> (-lst Univ) -String)]
  )

--- a/typed/debug/report/helpers.rkt
+++ b/typed/debug/report/helpers.rkt
@@ -4,17 +4,20 @@
 
 (type-environment
  ;; type annotations for report helpers go here:
+
  [pass-through-values
   ;; (∀ (X ...)
   ;;   (-> (-> (values X ...))
   ;;       (-> (List X ...) Void)
   ;;       (values X ...)))
-
   (-polydots (x)
     (cl->*
      (->
       (-> (-values-dots (list) x 'x))
       (-> (make-ListDots x 'x) -Void)
       (-values-dots (list) x 'x))))]
- [stringify-results (-> (-lst Univ) -String)]
+
+ [effect/report       (-> Univ           (-> (-lst Univ) -Void))]
+ [effect/report/line  (-> Univ -Nat      (-> (-lst Univ) -Void))]
+ [effect/report/file  (-> Univ -Nat Univ (-> (-lst Univ) -Void))]
  )


### PR DESCRIPTION
With one value, works the same as before. With multiple values, prints `(values v ...)`